### PR TITLE
Changing build and published structure

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,1 @@
-.gitignore
-.idea/
-dist/I*
-src/
-typings/
-tsconfig.json
-typings.json
+npm-debug.log

--- a/angular-2-local-storage.d.ts
+++ b/angular-2-local-storage.d.ts
@@ -1,1 +1,0 @@
-export { LocalStorageService, LOCAL_STORAGE_SERVICE_CONFIG } from './dist/angular-2-local-storage'

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { LocalStorageService, LOCAL_STORAGE_SERVICE_CONFIG } from './src/angular-2-local-storage'

--- a/package.json
+++ b/package.json
@@ -1,12 +1,21 @@
 {
   "name": "angular-2-local-storage",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "LocalStorageService for Angular 2 with mostly the same API (and most of the code) from angular-local-storage",
-  "main": "dist/angular-2-local-storage.js",
+  "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
-    "compile": "tsc"
+    "compile": "rimraf ./dist && tsc",
+    "postinstall": "typings install",
+    "publish": "rimraf ./dist && tsc && cp-cli ./package.json ./dist/package.json && cp-cli ./README.md ./dist/README.md && cp-cli ./.npmignore ./dist/.npmignore && cd ./dist && npm publish"
   },
   "author": "Craig Spence <craigspence0@gmail.com>",
+  "contributors": [
+    {
+      "name": "Elwyn Benson",
+      "email": "elwyn@L1.co.nz"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/phenomnomnominal/angular-2-local-storage.git"
@@ -17,8 +26,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@angular/core": "2.0.0-rc.1",
-    "rxjs": "5.0.0-beta.6",
-    "typescript": "1.8.10"
+    "@angular/core": "2.0.0-rc.4",
+    "cp-cli": "1.0.2",
+    "rimraf": "2.5.4",
+    "rxjs": "5.0.0-beta.10",
+    "typescript": "1.8.10",
+    "typings": "1.3.2"
   }
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../typings/browser.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "mapRoot": "../dist/",
@@ -10,14 +10,14 @@
     "noEmitOnError": true,
     "noImplicitAny": false,
     "outDir": "dist/",
-    "rootDir": "src/",
+    "rootDir": ".",
     "sourceMap": true,
     "target": "es5",
     "inlineSources": false
   },
 
   "files": [
-    "src/angular-2-local-storage.ts",
-    "src/typings.d.ts"
+    "./index.ts",
+    "./typings.d.ts"
   ]
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="./typings/browser.d.ts" />


### PR DESCRIPTION
Modified the way the project builds and publishes so as to make the consuming application have an easier time.

Now builds everything into `dist`, copies relevant root files in there also, and publishes from the `dist` subdirectory rather than the project root, resulting in a thinner package.