### PR TITLE
Removing 'rxjs/Rx' import as it pulls in the whole Rx lib

### DIFF
--- a/src/LocalStorageService.ts
+++ b/src/LocalStorageService.ts
@@ -7,7 +7,9 @@ import INotifyOptions from './INotifyOptions';
 
 // Angular:
 import { Inject } from '@angular/core';
-import { Observable, Subscriber } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import { Subscriber } from 'rxjs/Subscriber';
+import 'rxjs/add/operator/share';
 
 // Dependencies:
 import { LOCAL_STORAGE_SERVICE_CONFIG } from './LocalStorageServiceConfig';


### PR DESCRIPTION
Replaced with just the used dependencies.