### PR TITLE
Angular 10: Update local-storage.module.d.ts

### DIFF
--- a/dist/local-storage.module.d.ts
+++ b/dist/local-storage.module.d.ts
@@ -1,5 +1,5 @@
 import { ModuleWithProviders } from '@angular/core';
 import { ILocalStorageServiceConfig } from './local-storage.config.interface';
 export declare class LocalStorageModule {
-    static forRoot(userConfig?: ILocalStorageServiceConfig): ModuleWithProviders;
+    static forRoot(userConfig?: ILocalStorageServiceConfig): ModuleWithProviders<LocalStorageModule>;
 }


### PR DESCRIPTION
Angular 10 has deprecated the use of ModuleWithProviders type without a generic.